### PR TITLE
remove 'event SetPriceOracle'

### DIFF
--- a/contracts/AMM.vy
+++ b/contracts/AMM.vy
@@ -72,9 +72,6 @@ event SetFee:
 event SetAdminFee:
     fee: uint256
 
-event SetPriceOracle:
-    price_oracle: address
-
 
 MAX_TICKS: constant(int256) = 50
 MAX_TICKS_UINT: constant(uint256) = 50


### PR DESCRIPTION
can be removed because the related setter was removed in the following commit: https://github.com/curvefi/curve-stablecoin/commit/46bfb099aea89f784fe074b8b2853f3f4e4100ed