### PR TITLE
fix: only create new address provider id if ID is not occupied

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,4 +1,4 @@
-name: curve-dao-operations
+name: curve-stablecoin
 
 plugins:
   - name: vyper

--- a/scripts/ape-deploy.py
+++ b/scripts/ape-deploy.py
@@ -21,6 +21,7 @@ rtokens = {
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 POOL_NAME = "crvUSD/{name}"
 POOL_SYMBOL = "crvUSD{name}"
+STABLESWAP_FACTORY_ADDRESS_PROVIDER_ID = 8
 
 OWNERSHIP_ADMIN = "0x40907540d8a6C65c637785e8f8B742ae6b0b9968"
 PARAMETER_ADMIN = "0x4EEb3bA4f221cA16ed4A0cC7254E2E32DF948c5f"
@@ -168,10 +169,25 @@ def deploy(network):
             # Put factory in address provider / registry
             address_provider = Contract(ADDRESS_PROVIDER)
             address_provider_admin = Contract(address_provider.admin())
-            address_provider_admin.execute(
+            
+            if address_provider.get_address(STABLESWAP_FACTORY_ADDRESS_PROVIDER_ID) == ZERO_ADDRESS:
+            
+                address_provider_admin.execute(
+                        address_provider,
+                        address_provider.add_new_id.encode_input(swap_factory, 'crvUSD plain pools'),
+                        **kw
+                )
+                
+            else:
+                
+                address_provider_admin.execute(
                     address_provider,
-                    address_provider.add_new_id.encode_input(swap_factory, 'crvUSD plain pools'),
-                    **kw)
+                    address_provider.set_address.encode_input(
+                        STABLESWAP_FACTORY_ADDRESS_PROVIDER_ID,
+                        swap_factory,
+                        **kw
+                    ),
+                ) 
 
             pools = {}
 

--- a/tests_forked/conftest.py
+++ b/tests_forked/conftest.py
@@ -21,6 +21,7 @@ def pytest_configure():
     pytest.ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
     pytest.POOL_NAME = "crvUSD/{name}"
     pytest.POOL_SYMBOL = "crvUSD{name}"
+    pytest.STABLESWAP_FACTORY_ADDRESS_PROVIDER_ID = 8
 
     pytest.stable_A = 500  # initially, can go higher later
     pytest.stable_fee = 1000000  # 0.01%
@@ -144,10 +145,24 @@ def address_provider(forked_admin, stableswap_factory):
 
     with accounts.use_sender("0x7EeAC6CDdbd1D0B8aF061742D41877D7F707289a"):
         address_provider_admin = Contract(address_provider.admin())
-        address_provider_admin.execute(
-            address_provider,
-            address_provider.add_new_id.encode_input(stableswap_factory, "crvUSD plain pools"),
-        )
+        
+        if address_provider.get_address(pytest.STABLESWAP_FACTORY_ADDRESS_PROVIDER_ID) == pytest.ZERO_ADDRESS:
+            
+            address_provider_admin.execute(
+                address_provider,
+                address_provider.add_new_id.encode_input(stableswap_factory, "crvUSD plain pools"),
+            )
+        
+        else:
+            
+            address_provider_admin.execute(
+                address_provider,
+                address_provider.set_address.encode_input(
+                    pytest.STABLESWAP_FACTORY_ADDRESS_PROVIDER_ID,
+                    stableswap_factory
+                ),
+            )    
+        
     return address_provider
 
 

--- a/tests_forked/conftest.py
+++ b/tests_forked/conftest.py
@@ -21,7 +21,7 @@ def pytest_configure():
     pytest.ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
     pytest.POOL_NAME = "crvUSD/{name}"
     pytest.POOL_SYMBOL = "crvUSD{name}"
-    pytest.STABLESWAP_FACTORY_ADDRESS_PROVIDER_ID = 8
+    pytest.STABLESWAP_FACTORY_ADDRESS_PROVIDER_ID = 8  # reserve slot for crvusd plain pools factory
 
     pytest.stable_A = 500  # initially, can go higher later
     pytest.stable_fee = 1000000  # 0.01%

--- a/tests_forked/test_address_provider_integration.py
+++ b/tests_forked/test_address_provider_integration.py
@@ -1,0 +1,15 @@
+import pytest
+
+from ape import Contract
+
+
+def test_address_provider_entry(stableswap_factory, address_provider):
+    
+    address_provider = Contract("0x0000000022D53366457F9d5E68Ec105046FC4383")
+    
+    assert address_provider.get_address(pytest.STABLESWAP_FACTORY_ADDRESS_PROVIDER_ID) == stableswap_factory.address
+    
+    if pytest.new_id_created:
+        assert address_provider.max_id() == pytest.max_id_before + 1
+    else:
+        assert address_provider.max_id() == pytest.max_id_before


### PR DESCRIPTION
Just a simple conditional to ensure stablecoin stableswap factory doesn't spawn new addressprovider ids every time we deploy a new version to test in prod...


and o boy, do we test in prod...