### PR TITLE
Peg Keeper Salvation

### DIFF
--- a/contracts/stabilizer/Salvation.vy
+++ b/contracts/stabilizer/Salvation.vy
@@ -1,0 +1,99 @@
+# @version 0.3.10
+"""
+@title Salvation
+@license MIT
+@author Curve.Fi
+@notice Contract used to buy out coins from PegKeeper
+"""
+
+interface ERC20:
+    def approve(_to: address, _value: uint256): nonpayable
+    def transfer(_to: address, _value: uint256) -> bool: nonpayable
+    def transferFrom(_from: address, _to: address, _value: uint256) -> bool: nonpayable
+    def balanceOf(_owner: address) -> uint256: view
+    def decimals() -> uint256: view
+
+interface CurvePool:
+    def add_liquidity(_amounts: uint256[2], _min_mint_amount: uint256) -> uint256: nonpayable
+    def remove_liquidity(_burn_amount: uint256, _min_amounts: uint256[N_COINS], _receiver: address = msg.sender) -> uint256[N_COINS]: nonpayable
+    def remove_liquidity_imbalance(_amounts: uint256[2], _max_burn_amount: uint256, _receiver: address = msg.sender) -> uint256: nonpayable
+    def remove_liquidity_one_coin(_burn_amount: uint256, i: int128, _min_received: uint256, _receiver: address = msg.sender) -> uint256: nonpayable
+    def exchange(i: int128, j: int128, _dx: uint256, _min_dy: uint256, _receiver: address = msg.sender) -> uint256: nonpayable
+    def coins(i: uint256) -> ERC20: view
+    def balances(i_coin: uint256) -> uint256: view
+    def price_oracle() -> uint256: view
+    def get_p() -> uint256: view
+    def balanceOf(arg0: address) -> uint256: view
+    def totalSupply() -> uint256: view
+    def fee() -> uint256: view
+
+interface PegKeeper:
+    def update(_beneficiary: address = msg.sender) -> uint256: nonpayable
+    def debt() -> uint256: view
+    def calc_profit() -> uint256: view
+    def estimate_caller_profit() -> uint256: view
+    def withdraw_profit() -> uint256: nonpayable
+
+
+N_COINS: constant(uint256) = 2
+FEE_DENOMINATOR: constant(uint256) = 10 ** 10
+EPS: constant(uint256) = 5 * 10 ** 14  # 0.05%
+
+
+@internal
+def _transfer_back(_coin: ERC20):
+    assert _coin.transfer(msg.sender, _coin.balanceOf(self), default_return_value=True)  # safe transfer
+
+
+@external
+def buy_out(_pool: CurvePool, _pk: PegKeeper, _ransom: uint256, _max_total_supply: uint256, _max_price: uint256=10**18) -> uint256:
+    """
+    @notice Buy out coin with crvUSD from Peg Keeper
+    @dev Need off-chain data for TotalSupply and Price
+    @param _pool Pool which is used for Peg Keeper
+    @param _pk Peg Keeper to buy out from
+    @param _ransom Amount of crvUSD to use to buy out
+    @param _max_total_supply Maximum totalSupply allowed for the pool to mitigate sandwich
+    @param _max_price Max coin price in crvUSD to allow to buy out
+    """
+    max_price: uint256 = min(_max_price, _pool.price_oracle() * (10 ** 18 + EPS) / 10 ** 18)
+    initial_price: uint256 = _pool.get_p()
+    assert initial_price <= max_price
+    assert _pool.totalSupply() <= _max_total_supply
+
+    initial_debt: uint256 = _pk.debt()
+    dec: uint256 = 10 ** (18 - _pool.coins(0).decimals())
+    initial_amounts: uint256[2] = [_pool.balances(0) * dec, _pool.balances(1)]
+
+    # Add crvUSD, so there is more crvUSD than TUSD and it is withdrawn
+    amount: uint256 = min(5 * initial_debt + initial_amounts[0] - initial_amounts[1], _ransom)
+    crvUSD: ERC20 = _pool.coins(1)
+    crvUSD.transferFrom(msg.sender, self, amount)
+    crvUSD.approve(_pool.address, max_value(uint256))
+    lp: uint256 = _pool.add_liquidity([0, amount], 0)
+
+    # PegKeeper takes back crvUSD
+    print(_pool.balances(0), _pool.balances(1), _pool.get_p())
+    # _pk.withdraw_profit()
+    print(_pk.calc_profit())
+    print(_pk.estimate_caller_profit())  # Should be 0 in case of 'unprofitable peg'
+    lp += _pk.update()
+
+    # Withdraw crvUSD to stabilize
+    withdraw_amount: uint256 = _pool.balances(1) - initial_amounts[1] * _pool.balances(0) * dec / initial_amounts[0]
+    _pool.remove_liquidity_imbalance(
+        [0, withdraw_amount],
+        lp,
+        msg.sender,
+    )
+
+    # Remove everything else
+    _pool.remove_liquidity(_pool.balanceOf(self), [0, 0], msg.sender)
+
+    assert convert(abs(convert(_pool.get_p(), int256) - convert(initial_price, int256)), uint256) * 10 ** 18 / initial_price < EPS
+
+    # Just in case
+    for coin in [_pool.coins(0), crvUSD, ERC20(_pool.address)]:
+        self._transfer_back(coin)
+
+    return initial_debt - _pk.debt()

--- a/scripts/boa-salvation.py
+++ b/scripts/boa-salvation.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+import boa
+import json
+import os
+import sys
+from getpass import getpass
+from eth_account import account
+from boa.network import NetworkEnv
+
+
+RANSOM = 15 * 10 ** 6 * 10 ** 18
+IDX = 3  # TUSD
+
+NETWORK = f"https://eth-mainnet.alchemyapi.io/v2/{os.environ['WEB3_ETHEREUM_MAINNET_ALCHEMY_API_KEY']}"
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+POOLS = [
+    "0x4dece678ceceb27446b35c672dc7d61f30bad69e",  # USDC/crvUSD
+    "0x390f3595bca2df7d23783dfd126427cceb997bf4",  # USDT/crvUSD
+    "0xca978a0528116dda3cba9acd3e68bc6191ca53d0",  # USDP/crvUSD
+    "0x34d655069f4cac1547e4c8ca284ffff5ad4a8db0",  # TUSD/crvUSD
+]
+PEG_KEEPERS = [
+    "0xaA346781dDD7009caa644A4980f044C50cD2ae22",  # USDC
+    "0xE7cd2b4EB1d98CD6a4A48B6071D46401Ac7DC5C8",  # USDT
+    "0x6B765d07cf966c745B340AdCa67749fE75B5c345",  # USDP
+    "0x1ef89Ed0eDd93D1EC09E4c07373f69C49f4dcCae",  # TUSD
+]
+CRVUSD = "0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E"
+SALVATION = ZERO_ADDRESS
+
+ETHERSCAN_API = os.environ["ETHERSCAN_TOKEN"]
+_contracts = {}
+
+
+def _pool(idx):
+    if POOLS[idx] not in _contracts:
+        # _contracts[POOLS[idx]] = boa.load_partial("contracts/StableSwap.vy").at(POOLS[idx])
+        _contracts[POOLS[idx]] = boa.from_etherscan(POOLS[idx], name="StableSwap", api_key=ETHERSCAN_API)
+    return _contracts[POOLS[idx]]
+
+
+def _peg_keeper(idx):
+    if PEG_KEEPERS[idx] not in _contracts:
+        # _contracts[PEG_KEEPERS[idx]] = boa.load_partial("contracts/stabilizer/PegKeeper.vy").at(PEG_KEEPERS[idx])
+        _contracts[PEG_KEEPERS[idx]] = boa.from_etherscan(PEG_KEEPERS[idx], name="PegKeeper", api_key=ETHERSCAN_API)
+    return _contracts[PEG_KEEPERS[idx]]
+
+
+def _coins(pool):
+    coins = [pool]
+    for coin in [pool.coins(0), CRVUSD]:
+        if coin not in _contracts:
+            _contracts[coin] = boa.from_etherscan(pool.coins(0), name="coin", api_key=ETHERSCAN_API)
+        coins.append(_contracts[coin])
+    return coins
+
+
+def deploy():
+    salvation = boa.load_partial("contracts/stabilizer/Salvation.vy")
+    if SALVATION != ZERO_ADDRESS:
+        return salvation.at(SALVATION)
+    return salvation.deploy()
+
+
+def buy_out(idx=IDX, ransom=RANSOM, max_total_supply=None, max_price=None, salvation=None):
+    pool, pk = _pool(idx), _peg_keeper(idx)
+    if not max_total_supply:
+        max_total_supply = pool.totalSupply() * 101 // 100
+    if not max_price:
+        max_price = pool.price_oracle() * 101 // 100
+    if not salvation:
+        salvation = deploy()
+
+    coins = _coins(pool)
+    initial_balances = [
+        coin.balanceOf(boa.env.eoa) for coin in coins
+    ]
+
+    bought_out = salvation.buy_out(pool, pk, ransom, max_total_supply, max_price)
+    print(f"Bought out: {bought_out / 10 ** 18:>11.2f} crvUSD")
+    print(f"Remaining:  {pk.debt() / 10 ** 18:>11.2f} crvUSD")
+
+    diffs = []
+    for coin, initial_balance in zip(coins, initial_balances):
+        delimiter = 10 ** coin.decimals()
+        new_balance = coin.balanceOf(boa.env.eoa)
+        diff = new_balance - initial_balance
+        print(f"{coin.symbol()}: {initial_balance / delimiter:.2f} -> {new_balance / delimiter:.2f} "
+              f"({'+' if diff > 0 else ''}{diff / delimiter:.2f})")
+        diffs.append(diff)
+    print(f"Total: {diffs[1] / pool.price_oracle() + diffs[2] / 10 ** 18:.2f} crvUSD")
+
+
+def simulate(idx=IDX, ransom=RANSOM):
+    print("Simulation")
+    salvation = deploy()
+    to = boa.env.eoa
+    if CRVUSD not in _contracts:
+        _contracts[CRVUSD] = boa.from_etherscan(CRVUSD, name="crvUSD", api_key=ETHERSCAN_API)
+    crvusd = _contracts[CRVUSD]
+
+    for i in range(5):
+        if _peg_keeper(idx).debt() < 10 ** 18:
+            print("Peg Keeper is free")
+            break
+
+        print(f"Iteration {i}")
+        with boa.env.prank("0xC9332fdCB1C491Dcc683bAe86Fe3cb70360738BC"):
+            balance = crvusd.balanceOf(to)
+            if balance < ransom:
+                crvusd.mint(to, ransom - balance)
+
+        crvusd.approve(salvation, ransom)
+
+        buy_out(idx, ransom, salvation=salvation)
+        boa.env.time_travel(seconds=15 * 60)  # PegKeeper:ACTION_DELAY
+        print()
+
+
+def account_load(fname):
+    path = os.path.expanduser(os.path.join('~', '.brownie', 'accounts', fname + '.json'))
+    with open(path, 'r') as f:
+        pkey = account.decode_keyfile_json(json.load(f), getpass())
+        return account.Account.from_key(pkey)
+
+
+if __name__ == '__main__':
+    if '--fork' in sys.argv[1:]:
+        boa.env.fork(NETWORK)
+
+        boa.env.eoa = '0xbabe61887f1de2713c6f97e567623453d3C79f67'
+        simulate()
+    else:
+        boa.set_env(NetworkEnv(NETWORK))
+        boa.env.add_account(account_load('babe'))
+        boa.env._fork_try_prefetch_state = False
+        buy_out()


### PR DESCRIPTION
# What I did
Added a contract to buy out coins from PegKeeper (V1). Logic is presented in [Salvation](https://github.com/curvefi/curve-stablecoin/blob/feat/peg-keeper-salvation/contracts/stabilizer/Salvation.vy) with corresponding [script](https://github.com/curvefi/curve-stablecoin/blob/feat/peg-keeper-salvation/scripts/boa-salvation.py).
Used the scenario described in [depeg](https://github.com/curvefi/curve-stablecoin-researches/blob/main/peg_keeper/depeg.md).

## buy_out
`buy_out(_safe=True)` is used to buy coins from PegKeeper without losses, meaning creating 0 arbitrage opportunities after operation. In this case exchanging of coin should be done afterwards if necessary.
`buy_out(_safe=False)` is used to exchange all coins to crvUSD immediately in the pool. This makes larger penalties from slippage, thence should be used with small amounts and extra precautions.