### PR TITLE
remove AMM interface in OneWayLendingFactory.vy

### DIFF
--- a/contracts/lending/OneWayLendingFactory.vy
+++ b/contracts/lending/OneWayLendingFactory.vy
@@ -30,12 +30,6 @@ interface Vault:
 interface Controller:
     def monetary_policy() -> address: view
 
-interface AMM:
-    def get_dy(i: uint256, j: uint256, in_amount: uint256) -> uint256: view
-    def get_dx(i: uint256, j: uint256, out_amount: uint256) -> uint256: view
-    def get_dydx(i: uint256, j: uint256, out_amount: uint256) -> (uint256, uint256): view
-    def exchange(i: uint256, j: uint256, in_amount: uint256, min_amount: uint256, _for: address) -> uint256[2]: nonpayable
-    def exchange_dy(i: uint256, j: uint256, out_amount: uint256, max_amount: uint256, _for: address) -> uint256[2]: nonpayable
 
 interface Pool:
     def price_oracle(i: uint256 = 0) -> uint256: view  # Universal method!


### PR DESCRIPTION
Remove the AMM interface for exchange methods from `OneWayLendingFactory.vy`, as it was removed in this commit:https://github.com/curvefi/curve-stablecoin/commit/939aa5d8a6cbc9b8a88a40dcfe907972375466be