### PR TITLE
Fix Peg Keeper V2 for -ng pools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "contracts/testing/stableswap-ng"]
+	path = contracts/testing/stableswap-ng
+	url = https://github.com/curvefi/stableswap-ng.git

--- a/contracts/price_oracles/AggregateStablePrice3.vy
+++ b/contracts/price_oracles/AggregateStablePrice3.vy
@@ -6,6 +6,7 @@
 """
 # Returns price of stablecoin in "dollars" based on multiple redeemable stablecoins
 # Recommended to use 3+ price sources
+# Version3: Works with -ng pools
 
 interface Stableswap:
     def price_oracle(i: uint256=0) -> uint256: view

--- a/contracts/price_oracles/AggregateStablePrice3.vy
+++ b/contracts/price_oracles/AggregateStablePrice3.vy
@@ -1,0 +1,253 @@
+# @version 0.3.10
+"""
+@title AggregatorStablePrice - aggregator of stablecoin prices for crvUSD
+@author Curve.Fi
+@license Copyright (c) Curve.Fi, 2020-2023 - all rights reserved
+"""
+# Returns price of stablecoin in "dollars" based on multiple redeemable stablecoins
+# Recommended to use 3+ price sources
+
+interface Stableswap:
+    def price_oracle(i: uint256=0) -> uint256: view
+    def coins(i: uint256) -> address: view
+    def get_virtual_price() -> uint256: view
+    def totalSupply() -> uint256: view
+
+
+struct PricePair:
+    pool: Stableswap
+    is_inverse: bool
+    include_index: bool
+
+
+event AddPricePair:
+    n: uint256
+    pool: Stableswap
+    is_inverse: bool
+
+event RemovePricePair:
+    n: uint256
+
+event MovePricePair:
+    n_from: uint256
+    n_to: uint256
+
+event SetAdmin:
+    admin: address
+
+
+MAX_PAIRS: constant(uint256) = 20
+MIN_LIQUIDITY: constant(uint256) = 100_000 * 10**18  # Only take into account pools with enough liquidity
+
+STABLECOIN: immutable(address)
+SIGMA: immutable(uint256)
+price_pairs: public(PricePair[MAX_PAIRS])
+n_price_pairs: uint256
+
+last_timestamp: public(uint256)
+last_tvl: public(uint256[MAX_PAIRS])
+TVL_MA_TIME: public(constant(uint256)) = 50000  # s
+last_price: public(uint256)
+
+admin: public(address)
+
+
+@external
+def __init__(stablecoin: address, sigma: uint256, admin: address):
+    STABLECOIN = stablecoin
+    SIGMA = sigma  # The change is so rare that we can change the whole thing altogether
+    self.admin = admin
+    self.last_price = 10**18
+    self.last_timestamp = block.timestamp
+
+
+@external
+def set_admin(_admin: address):
+    # We are not doing commit / apply because the owner will be a voting DAO anyway
+    # which has vote delays
+    assert msg.sender == self.admin
+    self.admin = _admin
+    log SetAdmin(_admin)
+
+
+@external
+@pure
+def sigma() -> uint256:
+    return SIGMA
+
+
+@external
+@pure
+def stablecoin() -> address:
+    return STABLECOIN
+
+
+@external
+def add_price_pair(_pool: Stableswap):
+    assert msg.sender == self.admin
+    price_pair: PricePair = empty(PricePair)
+    price_pair.pool = _pool
+    success: bool = raw_call(
+        _pool.address, _abi_encode(convert(0, uint256), method_id=method_id("price_oracle(uint256)")),
+        revert_on_failure=False
+    )
+    if success:
+        price_pair.include_index = True
+    coins: address[2] = [_pool.coins(0), _pool.coins(1)]
+    if coins[0] == STABLECOIN:
+        price_pair.is_inverse = True
+    else:
+        assert coins[1] == STABLECOIN
+    n: uint256 = self.n_price_pairs
+    self.price_pairs[n] = price_pair  # Should revert if too many pairs
+    self.last_tvl[n] = _pool.totalSupply()
+    self.n_price_pairs = n + 1
+    log AddPricePair(n, _pool, price_pair.is_inverse)
+
+
+@external
+def remove_price_pair(n: uint256):
+    assert msg.sender == self.admin
+    n_max: uint256 = self.n_price_pairs - 1
+    assert n <= n_max
+
+    if n < n_max:
+        self.price_pairs[n] = self.price_pairs[n_max]
+        log MovePricePair(n_max, n)
+    self.n_price_pairs = n_max
+    log RemovePricePair(n)
+
+
+@internal
+@pure
+def exp(power: int256) -> uint256:
+    if power <= -41446531673892821376:
+        return 0
+
+    if power >= 135305999368893231589:
+        raise "exp overflow"
+
+    x: int256 = unsafe_div(unsafe_mul(power, 2**96), 10**18)
+
+    k: int256 = unsafe_div(
+        unsafe_add(
+            unsafe_div(unsafe_mul(x, 2**96), 54916777467707473351141471128),
+            2**95),
+        2**96)
+    x = unsafe_sub(x, unsafe_mul(k, 54916777467707473351141471128))
+
+    y: int256 = unsafe_add(x, 1346386616545796478920950773328)
+    y = unsafe_add(unsafe_div(unsafe_mul(y, x), 2**96), 57155421227552351082224309758442)
+    p: int256 = unsafe_sub(unsafe_add(y, x), 94201549194550492254356042504812)
+    p = unsafe_add(unsafe_div(unsafe_mul(p, y), 2**96), 28719021644029726153956944680412240)
+    p = unsafe_add(unsafe_mul(p, x), (4385272521454847904659076985693276 * 2**96))
+
+    q: int256 = x - 2855989394907223263936484059900
+    q = unsafe_add(unsafe_div(unsafe_mul(q, x), 2**96), 50020603652535783019961831881945)
+    q = unsafe_sub(unsafe_div(unsafe_mul(q, x), 2**96), 533845033583426703283633433725380)
+    q = unsafe_add(unsafe_div(unsafe_mul(q, x), 2**96), 3604857256930695427073651918091429)
+    q = unsafe_sub(unsafe_div(unsafe_mul(q, x), 2**96), 14423608567350463180887372962807573)
+    q = unsafe_add(unsafe_div(unsafe_mul(q, x), 2**96), 26449188498355588339934803723976023)
+
+    return shift(
+        unsafe_mul(convert(unsafe_div(p, q), uint256), 3822833074963236453042738258902158003155416615667),
+        unsafe_sub(k, 195))
+
+
+@internal
+@view
+def _ema_tvl() -> DynArray[uint256, MAX_PAIRS]:
+    tvls: DynArray[uint256, MAX_PAIRS] = []
+    last_timestamp: uint256 = self.last_timestamp
+    alpha: uint256 = 10**18
+    if last_timestamp < block.timestamp:
+        alpha = self.exp(- convert((block.timestamp - last_timestamp) * 10**18 / TVL_MA_TIME, int256))
+    n_price_pairs: uint256 = self.n_price_pairs
+
+    for i in range(MAX_PAIRS):
+        if i == n_price_pairs:
+            break
+        tvl: uint256 = self.last_tvl[i]
+        if alpha != 10**18:
+            # alpha = 1.0 when dt = 0
+            # alpha = 0.0 when dt = inf
+            new_tvl: uint256 = self.price_pairs[i].pool.totalSupply()  # We don't do virtual price here to save on gas
+            tvl = (new_tvl * (10**18 - alpha) + tvl * alpha) / 10**18
+        tvls.append(tvl)
+
+    return tvls
+
+
+@external
+@view
+def ema_tvl() -> DynArray[uint256, MAX_PAIRS]:
+    return self._ema_tvl()
+
+
+@internal
+@view
+def _price(tvls: DynArray[uint256, MAX_PAIRS]) -> uint256:
+    n: uint256 = self.n_price_pairs
+    prices: uint256[MAX_PAIRS] = empty(uint256[MAX_PAIRS])
+    D: uint256[MAX_PAIRS] = empty(uint256[MAX_PAIRS])
+    Dsum: uint256 = 0
+    DPsum: uint256 = 0
+    for i in range(MAX_PAIRS):
+        if i == n:
+            break
+        price_pair: PricePair = self.price_pairs[i]
+        pool_supply: uint256 = tvls[i]
+        if pool_supply >= MIN_LIQUIDITY:
+            p: uint256 = 0
+            if price_pair.include_index:
+                p = price_pair.pool.price_oracle(0)
+            else:
+                p = price_pair.pool.price_oracle()
+            if price_pair.is_inverse:
+                p = 10**36 / p
+            prices[i] = p
+            D[i] = pool_supply
+            Dsum += pool_supply
+            DPsum += pool_supply * p
+    if Dsum == 0:
+        return 10**18  # Placeholder for no active pools
+    p_avg: uint256 = DPsum / Dsum
+    e: uint256[MAX_PAIRS] = empty(uint256[MAX_PAIRS])
+    e_min: uint256 = max_value(uint256)
+    for i in range(MAX_PAIRS):
+        if i == n:
+            break
+        p: uint256 = prices[i]
+        e[i] = (max(p, p_avg) - min(p, p_avg))**2 / (SIGMA**2 / 10**18)
+        e_min = min(e[i], e_min)
+    wp_sum: uint256 = 0
+    w_sum: uint256 = 0
+    for i in range(MAX_PAIRS):
+        if i == n:
+            break
+        w: uint256 = D[i] * self.exp(-convert(e[i] - e_min, int256)) / 10**18
+        w_sum += w
+        wp_sum += w * prices[i]
+    return wp_sum / w_sum
+
+
+@external
+@view
+def price() -> uint256:
+    return self._price(self._ema_tvl())
+
+
+@external
+def price_w() -> uint256:
+    if self.last_timestamp == block.timestamp:
+        return self.last_price
+    else:
+        ema_tvl: DynArray[uint256, MAX_PAIRS] = self._ema_tvl()
+        self.last_timestamp = block.timestamp
+        for i in range(MAX_PAIRS):
+            if i == len(ema_tvl):
+                break
+            self.last_tvl[i] = ema_tvl[i]
+        p: uint256 = self._price(ema_tvl)
+        self.last_price = p
+        return p

--- a/contracts/stabilizer/PegKeeperRegulator.vy
+++ b/contracts/stabilizer/PegKeeperRegulator.vy
@@ -54,7 +54,7 @@ struct PegKeeperInfo:
     peg_keeper: PegKeeper
     pool: StableSwap
     is_inverse: bool
-    add_index: bool
+    include_index: bool
 
 enum Killed:
     Provide  # 1
@@ -109,7 +109,7 @@ def _get_price(_info: PegKeeperInfo) -> uint256:
     @return Price of the coin in STABLECOIN
     """
     price: uint256 = 0
-    if _info.add_index:
+    if _info.include_index:
         price = _info.pool.get_p(0)
     else:
         price = _info.pool.get_p()
@@ -125,7 +125,7 @@ def _get_price_oracle(_info: PegKeeperInfo) -> uint256:
     @return Price of the coin in STABLECOIN
     """
     price: uint256 = 0
-    if _info.add_index:
+    if _info.include_index:
         price = _info.pool.price_oracle(0)
     else:
         price = _info.pool.price_oracle()
@@ -242,8 +242,7 @@ def add_peg_keepers(_peg_keepers: DynArray[PegKeeper, MAX_LEN]):
     for pk in _peg_keepers:
         assert self.peg_keeper_i[pk] == empty(uint256)  # dev: duplicate
         pool: StableSwap = pk.pool()
-        success: bool = False
-        success = raw_call(
+        success: bool = raw_call(
             pool.address, _abi_encode(convert(0, uint256), method_id=method_id("price_oracle(uint256)")),
             revert_on_failure=False
         )
@@ -251,7 +250,7 @@ def add_peg_keepers(_peg_keepers: DynArray[PegKeeper, MAX_LEN]):
             peg_keeper: pk,
             pool: pool,
             is_inverse: pk.IS_INVERSE(),
-            add_index: success,
+            include_index: success,
         })
         self.peg_keepers.append(info)  # dev: too many pairs
         i += 1

--- a/contracts/stabilizer/PegKeeperRegulator.vy
+++ b/contracts/stabilizer/PegKeeperRegulator.vy
@@ -40,6 +40,9 @@ event DebtParameters:
     alpha: uint256
     beta: uint256
 
+event SetAggregator:
+    aggregator: address
+
 event SetKilled:
     is_killed: Killed
     by: address
@@ -318,6 +321,16 @@ def set_debt_parameters(_alpha: uint256, _beta: uint256):
     self.alpha = _alpha
     self.beta = _beta
     log DebtParameters(_alpha, _beta)
+
+
+@external
+def set_aggregator(_agg: Aggregator):
+    """
+    @notice Set new crvUSD price aggregator
+    """
+    assert msg.sender == self.admin
+    self.aggregator = _agg
+    log SetAggregator(_agg.address)
 
 
 @external

--- a/contracts/stabilizer/PegKeeperV2.vy
+++ b/contracts/stabilizer/PegKeeperV2.vy
@@ -25,9 +25,9 @@ interface CurvePoolOld:
     def remove_liquidity_imbalance(_amounts: uint256[2], _max_burn_amount: uint256) -> uint256: nonpayable
 
 interface CurvePoolNG:
-    def calc_token_amount(_amounts: DynArray[uint256, 2], _is_deposit: bool) -> uint256: view
-    def add_liquidity(_amounts: DynArray[uint256, 2], _min_mint_amount: uint256) -> uint256: nonpayable
-    def remove_liquidity_imbalance(_amounts: DynArray[uint256, 2], _max_burn_amount: uint256) -> uint256: nonpayable
+    def calc_token_amount(_amounts: DynArray[uint256, 8], _is_deposit: bool) -> uint256: view
+    def add_liquidity(_amounts: DynArray[uint256, 8], _min_mint_amount: uint256) -> uint256: nonpayable
+    def remove_liquidity_imbalance(_amounts: DynArray[uint256, 8], _max_burn_amount: uint256) -> uint256: nonpayable
 
 interface ERC20:
     def approve(_spender: address, _amount: uint256): nonpayable

--- a/contracts/testing/MockRateOracle.vy
+++ b/contracts/testing/MockRateOracle.vy
@@ -1,0 +1,29 @@
+#pragma version 0.3.10
+"""
+@title MockRateOracle
+@notice Mock to tweak rate
+"""
+
+rates: public(uint256[2])
+
+
+@external
+def __init__():
+    self.rates = [10 ** 18, 10 ** 18]
+
+
+@view
+@external
+def get00() -> uint256:
+    return self.rates[0]
+
+
+@view
+@external
+def get11() -> uint256:
+    return self.rates[1]
+
+
+@external
+def set(i: uint256, rate: uint256):
+    self.rates[i] = rate

--- a/contracts/testing/SwapFactory.vy
+++ b/contracts/testing/SwapFactory.vy
@@ -11,6 +11,13 @@ interface Swap:
     ): nonpayable
     def factory() -> address: view
 
+interface FactoryNG:
+    def deploy_plain_pool(_name: String[32], _symbol: String[10], _coins: DynArray[address, MAX_COINS], _A: uint256,
+                          _fee: uint256, _offpeg_fee_multiplier: uint256, _ma_exp_time: uint256,
+                          _implementation_idx: uint256, _asset_types: DynArray[uint8, MAX_COINS],
+                          _method_ids: DynArray[bytes4, MAX_COINS], _oracles: DynArray[address, MAX_COINS],
+    ) -> address: nonpayable
+
 interface ERC20:
     def balanceOf(_addr: address) -> uint256: view
     def decimals() -> uint256: view
@@ -18,11 +25,14 @@ interface ERC20:
     def approve(_spender: address, _amount: uint256): nonpayable
 
 
+MAX_COINS: constant(uint256) = 4
 IMPL: immutable(address)
 n: public(uint256)
 pools: public(HashMap[uint256, address])
 admin: public(address)
 
+factory_ng: FactoryNG
+rate_oracle: address
 
 @external
 def __init__(impl: address):
@@ -42,3 +52,18 @@ def deploy(coin_a: ERC20, coin_b: ERC20) -> address:
     self.pools[self.n] = pool.address
     self.n += 1
     return pool.address
+
+
+@external
+def deploy_ng(coin_a: ERC20, coin_b: ERC20) -> address:
+    assert self.factory_ng.address != empty(address), "Factory not set"
+    pool: address = self.factory_ng.deploy_plain_pool(
+        'TestName-ng', 'TST-ng',
+        [coin_a.address, coin_b.address],
+        100, 0, 10000000000, 866, 0, [1, 1],
+        [method_id("get00()", output_type=bytes4), method_id("get11()", output_type=bytes4)],
+        [self.rate_oracle, self.rate_oracle],
+    )
+    self.pools[self.n] = pool
+    self.n += 1
+    return pool

--- a/tests/lendborrow/stabilize/stateful/base.py
+++ b/tests/lendborrow/stabilize/stateful/base.py
@@ -25,18 +25,12 @@ class StateMachine(RuleBasedStateMachine):
         with boa.env.prank(self.admin):
             for swap in self.swaps:
                 self.fees.append(swap.fee())
-                swap.commit_new_fee(0)
-            boa.env.time_travel(7 * 86400)
-            for swap in self.swaps:
-                swap.apply_new_fee()
+                swap.eval(f"self.fee = 0")
 
     def _enable_fees(self):
         with boa.env.prank(self.admin):
             for swap, fee in zip(self.swaps, self.fees):
-                swap.commit_new_fee(fee)
-            boa.env.time_travel(7 * 86400)
-            for swap in self.swaps:
-                swap.apply_new_fee()
+                swap.eval(f"self.fee = {fee}")
 
     @rule(idx=st_idx, pct=st_pct, pool_idx=st_pool)
     def add_one_coin(self, idx, pct, pool_idx):

--- a/tests/lendborrow/stabilize/stateful/base.py
+++ b/tests/lendborrow/stabilize/stateful/base.py
@@ -1,7 +1,7 @@
 import boa
 from hypothesis import strategies as st
 from hypothesis.stateful import RuleBasedStateMachine, rule, invariant
-from boa.vyper.contract import BoaError
+from boa import BoaError
 from ..conftest import BASE_AMOUNT
 
 

--- a/tests/lendborrow/stabilize/stateful/test_agg_monetary_policy.py
+++ b/tests/lendborrow/stabilize/stateful/test_agg_monetary_policy.py
@@ -1,7 +1,7 @@
 from hypothesis import settings
 from hypothesis import strategies as st
 from hypothesis.stateful import RuleBasedStateMachine, run_state_machine_as_test, initialize, rule, invariant
-from boa.vyper.contract import VyperContract
+from boa.contracts.vyper.vyper_contract import VyperContract
 import boa
 
 

--- a/tests/lendborrow/stabilize/stateful/test_agg_monetary_policy.py
+++ b/tests/lendborrow/stabilize/stateful/test_agg_monetary_policy.py
@@ -20,7 +20,7 @@ class AggMonetaryPolicyCreation(RuleBasedStateMachine):
     target_debt_fraction = st.integers(min_value=1, max_value=10**18)
     MPOLICY = boa.load_partial('contracts/mpolicies/AggMonetaryPolicy2.vy')
     ERC20 = boa.load_partial('contracts/testing/ERC20Mock.vy')
-    PK = boa.load_partial('contracts/stabilizer/PegKeeper.vy')
+    PK = boa.load_partial('contracts/stabilizer/PegKeeperV2.vy')
 
     def __init__(self):
         super().__init__()
@@ -32,7 +32,7 @@ class AggMonetaryPolicyCreation(RuleBasedStateMachine):
         self.one_usd = []
         self.swaps = []
         self.peg_keepers = []
-        self.agg = boa.load('contracts/price_oracles/AggregateStablePrice2.vy', self.stablecoin.address, 10**15, self.admin)
+        self.agg = boa.load('contracts/price_oracles/AggregateStablePrice3.vy', self.stablecoin.address, 10**15, self.admin)
         self.reg = boa.load('contracts/stabilizer/PegKeeperRegulator.vy', self.stablecoin.address, self.agg, self.admin, self.admin)
 
     @initialize(digits=many_digits)

--- a/tests/lendborrow/stabilize/stateful/test_diff.py
+++ b/tests/lendborrow/stabilize/stateful/test_diff.py
@@ -1,6 +1,6 @@
 import pytest
 import boa
-from boa.vyper.contract import BoaError
+from boa import BoaError
 from hypothesis import settings
 from hypothesis.stateful import run_state_machine_as_test, invariant
 from hypothesis._settings import HealthCheck

--- a/tests/lendborrow/stabilize/stateful/test_profit.py
+++ b/tests/lendborrow/stabilize/stateful/test_profit.py
@@ -1,6 +1,6 @@
 import pytest
 import boa
-from boa.vyper.contract import BoaError
+from boa import BoaError
 from hypothesis import settings
 from hypothesis.stateful import run_state_machine_as_test, invariant
 from hypothesis._settings import HealthCheck

--- a/tests/lendborrow/stabilize/stateful/test_profit.py
+++ b/tests/lendborrow/stabilize/stateful/test_profit.py
@@ -64,10 +64,7 @@ def test_profit(
     fee = 4 * 10 ** 7
     with boa.env.prank(admin):
         for swap in swaps:
-            swap.commit_new_fee(fee)
-        boa.env.time_travel(4 * 86400)
-        for swap in swaps:
-            swap.apply_new_fee()
+            swap.eval(f"self.fee = {fee}")
     StateMachine.TestCase.settings = settings(max_examples=100, stateful_step_count=40, suppress_health_check=HealthCheck.all())
     for k, v in locals().items():
         setattr(StateMachine, k, v)
@@ -87,10 +84,7 @@ def test_unprofitable_peg(
     fee = 4 * 10**7
     with boa.env.prank(admin):
         for swap in swaps:
-            swap.commit_new_fee(fee)
-        boa.env.time_travel(4 * 86400)
-        for swap in swaps:
-            swap.apply_new_fee()
+            swap.eval(f"self.fee = {fee}")
     for k, v in locals().items():
         setattr(StateMachine, k, v)
     state = StateMachine()

--- a/tests/lendborrow/stabilize/stateful/test_stable_peg_caller_profit.py
+++ b/tests/lendborrow/stabilize/stateful/test_stable_peg_caller_profit.py
@@ -1,6 +1,6 @@
 import pytest
 import boa
-from boa.vyper.contract import BoaError
+from boa import BoaError
 from hypothesis import settings
 from hypothesis.stateful import run_state_machine_as_test, invariant
 from hypothesis._settings import HealthCheck

--- a/tests/lendborrow/stabilize/stateful/test_stable_peg_caller_profit.py
+++ b/tests/lendborrow/stabilize/stateful/test_stable_peg_caller_profit.py
@@ -60,10 +60,7 @@ def test_stable_peg(
 ):
     with boa.env.prank(admin):
         for swap in swaps:
-            swap.commit_new_fee(4 * 10**7)
-        boa.env.time_travel(4 * 86400)
-        for swap in swaps:
-            swap.apply_new_fee()
+            swap.eval(f"self.fee = {4 * 10**7}")
 
     StateMachine.TestCase.settings = settings(max_examples=100, stateful_step_count=40, suppress_health_check=HealthCheck.all())
     for k, v in locals().items():
@@ -83,10 +80,7 @@ def test_expected_profit_amount(
 ):
     with boa.env.prank(admin):
         for swap in swaps:
-            swap.commit_new_fee(4 * 10**7)
-        boa.env.time_travel(4 * 86400)
-        for swap in swaps:
-            swap.apply_new_fee()
+            swap.eval(f"self.fee = {4 * 10**7}")
     for k, v in locals().items():
         setattr(StateMachine, k, v)
     state = StateMachine()
@@ -125,10 +119,7 @@ def test_expected_profit_amount_2(
 ):
     with boa.env.prank(admin):
         for swap in swaps:
-            swap.commit_new_fee(4 * 10**7)
-        boa.env.time_travel(4 * 86400)
-        for swap in swaps:
-            swap.apply_new_fee()
+            swap.eval(f"self.fee = {4 * 10 ** 7}")
     for k, v in locals().items():
         setattr(StateMachine, k, v)
     state = StateMachine()
@@ -203,10 +194,7 @@ def test_calc_revert(
 ):
     with boa.env.prank(admin):
         for swap in swaps:
-            swap.commit_new_fee(4 * 10**7)
-        boa.env.time_travel(4 * 86400)
-        for swap in swaps:
-            swap.apply_new_fee()
+            swap.eval(f"self.fee = {4 * 10 ** 7}")
     for k, v in locals().items():
         setattr(StateMachine, k, v)
     state = StateMachine()

--- a/tests/lendborrow/stabilize/stateful/test_withdraw_profit.py
+++ b/tests/lendborrow/stabilize/stateful/test_withdraw_profit.py
@@ -1,7 +1,7 @@
 import pytest
 import boa
 from . import base
-from boa.vyper.contract import BoaError
+from boa import BoaError
 from hypothesis import settings
 from hypothesis.stateful import run_state_machine_as_test, rule, invariant
 

--- a/tests/lendborrow/stabilize/stateful/test_withdraw_profit.py
+++ b/tests/lendborrow/stabilize/stateful/test_withdraw_profit.py
@@ -53,6 +53,8 @@ class StateMachine(base.StateMachine):
                 with boa.env.prank(self.alice):
                     swap.add_liquidity([0, amount], 0)
                 self._enable_fees()
+                if hasattr(swap, "offpeg_fee_multiplier"):
+                    swap.eval("self.offpeg_fee_multiplier = 0")
 
                 boa.env.time_travel(15 * 60)
 
@@ -84,10 +86,7 @@ def test_withdraw_profit(
 ):
     with boa.env.prank(admin):
         for swap in swaps:
-            swap.commit_new_fee(4 * 10**7)
-        boa.env.time_travel(4 * 86400)
-        for swap in swaps:
-            swap.apply_new_fee()
+            swap.eval(f"self.fee = {4 * 10 ** 7}")
 
     StateMachine.TestCase.settings = settings(max_examples=20, stateful_step_count=40)
     for k, v in locals().items():
@@ -110,10 +109,7 @@ def test_withdraw_profit_example_1(
 
     with boa.env.prank(admin):
         for swap in swaps:
-            swap.commit_new_fee(4 * 10**7)
-        boa.env.time_travel(4 * 86400)
-        for swap in swaps:
-            swap.apply_new_fee()
+            swap.eval(f"self.fee = {4 * 10 ** 7}")
 
     StateMachine.TestCase.settings = settings(max_examples=20, stateful_step_count=40)
     for k, v in locals().items():

--- a/tests/lendborrow/stabilize/unitary/test_pk_profit.py
+++ b/tests/lendborrow/stabilize/unitary/test_pk_profit.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.usefixtures(
 
 
 @pytest.fixture(scope="module")
-def make_profit(swaps, redeemable_tokens, stablecoin, alice, admin):
+def make_profit(swaps, redeemable_tokens, stablecoin, alice, admin, set_fee):
     def _inner(amount, i=None):
         """Amount to add to balances."""
         for j, (rtoken, swap) in enumerate(zip(redeemable_tokens, swaps)):
@@ -21,10 +21,7 @@ def make_profit(swaps, redeemable_tokens, stablecoin, alice, admin):
             if exchange_amount == 0:
                 continue
 
-            with boa.env.prank(admin):
-                swap.commit_new_fee(10**9)
-                boa.env.time_travel(4 * 86400)
-                swap.apply_new_fee()
+            set_fee(swap, 10**9)
 
             with boa.env.prank(alice):
                 rtoken._mint_for_testing(alice, exchange_amount)
@@ -34,10 +31,7 @@ def make_profit(swaps, redeemable_tokens, stablecoin, alice, admin):
                 stablecoin.approve(swap.address, out)
                 swap.exchange(1, 0, out, 0)
 
-            with boa.env.prank(admin):
-                swap.commit_new_fee(0)
-                boa.env.time_travel(4 * 86400)
-                swap.apply_new_fee()
+            set_fee(swap, 0)
 
     return _inner
 
@@ -143,7 +137,7 @@ def test_profit_receiver(
         assert swap.balanceOf(receiver) > 0
 
 
-def test_unprofitable_peg(swaps, peg_keepers, redeemable_tokens, stablecoin, alice, imbalance_pool, admin):
+def test_unprofitable_peg(swaps, peg_keepers, redeemable_tokens, stablecoin, alice, imbalance_pool, admin, set_fee):
     for swap, peg_keeper, rtoken in zip(swaps, peg_keepers, redeemable_tokens):
         with boa.env.anchor():
             # Leave a little of debt
@@ -157,10 +151,7 @@ def test_unprofitable_peg(swaps, peg_keepers, redeemable_tokens, stablecoin, ali
             able_to_add = stablecoin.balanceOf(peg_keeper) // rtoken_mul
             imbalance_pool(swap, 0, 5 * able_to_add, add_diff=True)
 
-            with boa.env.prank(admin):
-                swap.commit_new_fee(5 * 10**9)
-                boa.env.time_travel(4 * 86400)
-                swap.apply_new_fee()
+            set_fee(swap, 5 * 10**9)
 
             boa.env.time_travel(15 * 60)
             with boa.reverts('peg unprofitable'):  # dev: peg was unprofitable

--- a/tests/lendborrow/stabilize/unitary/test_pk_regulator.py
+++ b/tests/lendborrow/stabilize/unitary/test_pk_regulator.py
@@ -150,11 +150,12 @@ def test_set_killed(reg, peg_keepers, admin):
         assert not reg.withdraw_allowed(peg_keeper)
 
 
-def test_admin(reg, admin, alice):
+def test_admin(reg, admin, alice, agg):
     # initial parameters
     assert reg.worst_price_threshold() == 3 * 10 ** (18 - 4)
     assert reg.price_deviation() == 100 * 10 ** 18
     assert (reg.alpha(), reg.beta()) == (10 ** 18, 10 ** 18)
+    assert reg.aggregator() == agg.address
     assert reg.emergency_admin() == admin
     assert reg.is_killed() == 0
     assert reg.admin() == admin
@@ -167,6 +168,8 @@ def test_admin(reg, admin, alice):
             reg.set_price_deviation(10 ** 17)
         with boa.reverts():
             reg.set_debt_parameters(10 ** 18 // 2, 10 ** 18 // 5)
+        with boa.reverts():
+            reg.set_aggregator(alice)
         with boa.reverts():
             reg.set_emergency_admin(alice)
         with boa.reverts():
@@ -184,6 +187,9 @@ def test_admin(reg, admin, alice):
 
         reg.set_debt_parameters(10 ** 18 // 2, 10 ** 18 // 5)
         assert (reg.alpha(), reg.beta()) == (10 ** 18 // 2, 10 ** 18 // 5)
+
+        reg.set_aggregator(alice)
+        assert reg.aggregator() == alice
 
         reg.set_emergency_admin(alice)
         assert reg.emergency_admin() == alice

--- a/tests/lendborrow/stabilize/unitary/test_pk_regulator.py
+++ b/tests/lendborrow/stabilize/unitary/test_pk_regulator.py
@@ -7,7 +7,7 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 ADMIN_ACTIONS_DEADLINE = 3 * 86400
 
 
-def test_price_range(peg_keepers, swaps, stablecoin, admin, receiver, reg):
+def test_price_range(peg_keepers, swaps, stablecoin, admin, receiver, reg, rate_oracle):
     with boa.env.prank(admin):
         reg.set_price_deviation(10 ** 17)
         for peg_keeper in peg_keepers:
@@ -18,12 +18,18 @@ def test_price_range(peg_keepers, swaps, stablecoin, admin, receiver, reg):
         assert reg.withdraw_allowed(peg_keeper)
 
         # Move current price (get_p) a little
-        swap.eval("self.rate_multipliers[0] *= 2")
+        try:
+            swap.eval("self.rate_multipliers[0] *= 2")
+        except:
+            rate_oracle.set(1, 2 * 10 ** 18)
         assert reg.provide_allowed(peg_keeper)
         assert reg.withdraw_allowed(peg_keeper)
 
         # Move further
-        swap.eval("self.rate_multipliers[0] *= 5")
+        try:
+            swap.eval("self.rate_multipliers[0] *= 5")
+        except:
+            rate_oracle.set(1, 10 ** 19)
 
         assert not reg.provide_allowed(peg_keeper)
         assert not reg.withdraw_allowed(peg_keeper)

--- a/tests/lendborrow/stabilize/unitary/test_pk_withdraw.py
+++ b/tests/lendborrow/stabilize/unitary/test_pk_withdraw.py
@@ -96,15 +96,13 @@ def test_almost_balanced(
     alice,
     admin,
     peg_keepers,
-    peg_keeper_updater
+    peg_keeper_updater,
+    set_fee,
 ):
     for swap, peg_keeper in zip(swaps, peg_keepers):
         with boa.env.prank(alice):
             swap.add_liquidity([0, 10**18], 0)
-        with boa.env.prank(admin):
-            swap.commit_new_fee(10**6)
-            boa.env.time_travel(4 * 86400)
-            swap.apply_new_fee()
+        set_fee(swap, 10**6)
         with boa.reverts():  # dev: peg was unprofitable
             with boa.env.prank(peg_keeper_updater):
                 peg_keeper.update()


### PR DESCRIPTION
## What I did
- Distinguish and support -ng pools in `PegKeeperRegulator` and `PegKeeperV2`
- Add `AggregateStablePrice3` with -ng support
- Fix test for -ng pools

## How to test
[Fixtures](https://github.com/curvefi/curve-stablecoin/blob/7576b7c00041d7100d1f9ad0cbfe45fb64da7f98/tests/lendborrow/stabilize/conftest.py) `stableswap_a` corresponds to older version and `stableswap_b` to -ng pools, so all tests work against both types of pools.