### PR TITLE
Move fee_receiver from PegKeeperV2 to PegKeeperRegulator

### DIFF
--- a/contracts/stabilizer/PegKeeperRegulator.vy
+++ b/contracts/stabilizer/PegKeeperRegulator.vy
@@ -43,6 +43,9 @@ event DebtParameters:
 event SetAggregator:
     aggregator: address
 
+event SetFeeReceiver:
+    fee_receiver: address
+
 event SetKilled:
     is_killed: Killed
     by: address
@@ -76,15 +79,18 @@ aggregator: public(Aggregator)
 peg_keepers: public(DynArray[PegKeeperInfo, MAX_LEN])
 peg_keeper_i: HashMap[PegKeeper,  uint256]  # 1 + index of peg keeper in a list
 
+fee_receiver: public(address)
+
 is_killed: public(Killed)
 admin: public(address)
 emergency_admin: public(address)
 
 
 @external
-def __init__(_stablecoin: ERC20, _agg: Aggregator, _admin: address, _emergency_admin: address):
+def __init__(_stablecoin: ERC20, _agg: Aggregator, _fee_receiver: address, _admin: address, _emergency_admin: address):
     STABLECOIN = _stablecoin
     self.aggregator = _agg
+    self.fee_receiver = _fee_receiver
     self.admin = _admin
     self.emergency_admin = _emergency_admin
     log SetAdmin(_admin)
@@ -331,6 +337,16 @@ def set_aggregator(_agg: Aggregator):
     assert msg.sender == self.admin
     self.aggregator = _agg
     log SetAggregator(_agg.address)
+
+
+@external
+def set_fee_receiver(_fee_receiver: address):
+    """
+    @notice Set new PegKeeper's profit receiver
+    """
+    assert msg.sender == self.admin
+    self.fee_receiver = _fee_receiver
+    log SetFeeReceiver(_fee_receiver)
 
 
 @external

--- a/tests/stableborrow/stabilize/conftest.py
+++ b/tests/stableborrow/stabilize/conftest.py
@@ -205,10 +205,10 @@ def mock_peg_keepers(stablecoin):
 
 
 @pytest.fixture(scope="module")
-def reg(agg, stablecoin, mock_peg_keepers, admin):
+def reg(agg, stablecoin, mock_peg_keepers, receiver, admin):
     regulator = boa.load(
         'contracts/stabilizer/PegKeeperRegulator.vy',
-        stablecoin, agg, admin, admin
+        stablecoin, agg, receiver, admin, admin
     )
     with boa.env.prank(admin):
         regulator.set_price_deviation(10 ** 20)
@@ -225,7 +225,7 @@ def peg_keepers(stablecoin_a, stablecoin_b, stableswap_a, stableswap_b, controll
             pks.append(
                     boa.load(
                         'contracts/stabilizer/PegKeeperV2.vy',
-                        pool.address, receiver, 2 * 10**4,
+                        pool.address, 2 * 10**4,
                         controller_factory.address, reg.address, admin)
             )
         reg.add_peg_keepers([pk.address for pk in pks])

--- a/tests/stableborrow/stabilize/unitary/test_pk_admin_functions.py
+++ b/tests/stableborrow/stabilize/unitary/test_pk_admin_functions.py
@@ -5,15 +5,13 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 ADMIN_ACTIONS_DEADLINE = 3 * 86400
 
 
-def test_parameters(peg_keepers, swaps, stablecoin, admin, receiver, reg):
+def test_parameters(peg_keepers, swaps, stablecoin, admin, reg):
     for peg_keeper, swap in zip(peg_keepers, swaps):
         assert peg_keeper.pegged() == stablecoin.address
         assert peg_keeper.pool() == swap.address
 
         assert peg_keeper.admin() == admin
         assert peg_keeper.future_admin() == ZERO_ADDRESS
-
-        assert peg_keeper.receiver() == receiver
 
         assert peg_keeper.caller_share() == 2 * 10**4
         assert peg_keeper.regulator() == reg.address
@@ -105,14 +103,3 @@ def test_revert_new_admin(peg_keepers, admin, alice):
             pk.commit_new_admin(alice)
             pk.commit_new_admin(admin)
         assert pk.future_admin() == admin
-
-
-def test_set_new_receiver(peg_keepers, admin, alice, receiver):
-    for pk in peg_keepers:
-        with boa.reverts():  # dev: only admin
-            with boa.env.prank(alice):
-                pk.set_new_receiver(alice)
-        with boa.env.prank(admin):
-            pk.set_new_receiver(alice)
-
-        assert pk.receiver() == alice

--- a/tests/stableborrow/stabilize/unitary/test_pk_regulator.py
+++ b/tests/stableborrow/stabilize/unitary/test_pk_regulator.py
@@ -153,12 +153,13 @@ def test_set_killed(reg, peg_keepers, admin, stablecoin):
         assert not reg.withdraw_allowed(peg_keeper)
 
 
-def test_admin(reg, admin, alice, agg):
+def test_admin(reg, admin, alice, agg, receiver):
     # initial parameters
     assert reg.worst_price_threshold() == 3 * 10 ** (18 - 4)
     assert reg.price_deviation() == 100 * 10 ** 18
     assert (reg.alpha(), reg.beta()) == (10 ** 18, 10 ** 18)
     assert reg.aggregator() == agg.address
+    assert reg.fee_receiver() == receiver
     assert reg.emergency_admin() == admin
     assert reg.is_killed() == 0
     assert reg.admin() == admin
@@ -173,6 +174,8 @@ def test_admin(reg, admin, alice, agg):
             reg.set_debt_parameters(10 ** 18 // 2, 10 ** 18 // 5)
         with boa.reverts():
             reg.set_aggregator(alice)
+        with boa.reverts():
+            reg.set_fee_receiver(alice)
         with boa.reverts():
             reg.set_emergency_admin(alice)
         with boa.reverts():
@@ -193,6 +196,9 @@ def test_admin(reg, admin, alice, agg):
 
         reg.set_aggregator(alice)
         assert reg.aggregator() == alice
+
+        reg.set_fee_receiver(alice)
+        assert reg.fee_receiver() == alice
 
         reg.set_emergency_admin(alice)
         assert reg.emergency_admin() == alice


### PR DESCRIPTION
Follow common architecture with "Factory" having `fee_receiver` for its' children