### PR TITLE
[Patch] Make action_delay changeable

### DIFF
--- a/contracts/stabilizer/PegKeeperV2.vy
+++ b/contracts/stabilizer/PegKeeperV2.vy
@@ -62,7 +62,7 @@ event SetNewRegulator:
 
 
 # Time between providing/withdrawing coins
-action_delay: uint256
+action_delay: public(uint256)
 ADMIN_ACTIONS_DELAY: constant(uint256) = 3 * 86400
 
 PRECISION: constant(uint256) = 10 ** 18

--- a/contracts/stabilizer/PegKeeperV2.vy
+++ b/contracts/stabilizer/PegKeeperV2.vy
@@ -51,6 +51,9 @@ event CommitNewAdmin:
 event ApplyNewAdmin:
     admin: address
 
+event SetNewActionDelay:
+    action_delay: uint256
+
 event SetNewCallerShare:
     caller_share: uint256
 
@@ -59,7 +62,7 @@ event SetNewRegulator:
 
 
 # Time between providing/withdrawing coins
-ACTION_DELAY: constant(uint256) = 15 * 60
+action_delay: uint256
 ADMIN_ACTIONS_DELAY: constant(uint256) = 3 * 86400
 
 PRECISION: constant(uint256) = 10 ** 18
@@ -130,6 +133,9 @@ def __init__(
     assert _caller_share <= SHARE_PRECISION  # dev: bad part value
     self.caller_share = _caller_share
     log SetNewCallerShare(_caller_share)
+
+    self.action_delay = 12  # 1 block
+    log SetNewActionDelay(12)
 
     FACTORY = _factory
 
@@ -290,7 +296,7 @@ def estimate_caller_profit() -> uint256:
     @dev This method is not precise, real profit is always more because of increasing virtual price
     @return Expected amount of profit going to beneficiary
     """
-    if self.last_change + ACTION_DELAY > block.timestamp:
+    if self.last_change + self.action_delay > block.timestamp:
         return 0
 
     balance_pegged: uint256 = POOL.balances(I)
@@ -316,7 +322,7 @@ def update(_beneficiary: address = msg.sender) -> uint256:
     @param _beneficiary Beneficiary address
     @return Amount of profit received by beneficiary
     """
-    if self.last_change + ACTION_DELAY > block.timestamp:
+    if self.last_change + self.action_delay > block.timestamp:
         return 0
 
     balance_pegged: uint256 = POOL.balances(I)
@@ -361,6 +367,20 @@ def withdraw_profit() -> uint256:
 
 
 # ------------------------------- Admin methods --------------------------------
+
+
+@external
+@nonpayable
+def set_new_action_delay(_new_action_delay: uint256):
+    """
+    @notice Set new action delay
+    @param _new_action_delay Action delay in seconds
+    """
+    assert msg.sender == self.admin  # dev: only admin
+
+    self.action_delay = _new_action_delay
+
+    log SetNewActionDelay(_new_action_delay)
 
 
 @external

--- a/tests/stableborrow/stabilize/conftest.py
+++ b/tests/stableborrow/stabilize/conftest.py
@@ -341,7 +341,7 @@ def provide_token_to_peg_keepers_no_sleep(initial_amounts, swaps, peg_keepers, r
 
 @pytest.fixture(scope="module")
 def provide_token_to_peg_keepers(provide_token_to_peg_keepers_no_sleep):
-    boa.env.time_travel(15 * 60)
+    boa.env.time_travel(12)
 
 
 @pytest.fixture(scope="module")

--- a/tests/stableborrow/stabilize/stateful/base.py
+++ b/tests/stableborrow/stabilize/stateful/base.py
@@ -122,4 +122,4 @@ class StateMachine(RuleBasedStateMachine):
         Advance the clock by 15 minutes between each action.
         Needed for action_delay in Peg Keeper.
         """
-        boa.env.time_travel(15 * 60)
+        boa.env.time_travel(12)

--- a/tests/stableborrow/stabilize/stateful/test_agg_monetary_policy.py
+++ b/tests/stableborrow/stabilize/stateful/test_agg_monetary_policy.py
@@ -33,7 +33,7 @@ class AggMonetaryPolicyCreation(RuleBasedStateMachine):
         self.swaps = []
         self.peg_keepers = []
         self.agg = boa.load('contracts/price_oracles/AggregateStablePrice3.vy', self.stablecoin.address, 10**15, self.admin)
-        self.reg = boa.load('contracts/stabilizer/PegKeeperRegulator.vy', self.stablecoin.address, self.agg, self.admin, self.admin)
+        self.reg = boa.load('contracts/stabilizer/PegKeeperRegulator.vy', self.stablecoin.address, self.agg, self.admin, self.admin, self.admin)
 
     @initialize(digits=many_digits)
     def initializer(self, digits):
@@ -66,7 +66,7 @@ class AggMonetaryPolicyCreation(RuleBasedStateMachine):
             self.stablecoin.approve(swap.address, 2**256 - 1)
             # Deploy a peg keeper
             pk = self.PK.deploy(
-                    swap.address, self.admin, 5 * 10**4,
+                    swap.address, 5 * 10**4,
                     self.controller_factory.address, self.reg.address, self.admin)
         self.stablecoins.append(fedUSD)
         self.swaps.append(swap)

--- a/tests/stableborrow/stabilize/stateful/test_withdraw_profit.py
+++ b/tests/stableborrow/stabilize/stateful/test_withdraw_profit.py
@@ -56,7 +56,7 @@ class StateMachine(base.StateMachine):
                 if hasattr(swap, "offpeg_fee_multiplier"):
                     swap.eval("self.offpeg_fee_multiplier = 0")
 
-                boa.env.time_travel(15 * 60)
+                boa.env.time_travel(12)
 
                 try:
                     peg_keeper.update()

--- a/tests/stableborrow/stabilize/unitary/test_pk_delay.py
+++ b/tests/stableborrow/stabilize/unitary/test_pk_delay.py
@@ -2,7 +2,7 @@ import boa
 import pytest
 
 
-ACTION_DELAY = 15 * 60
+ACTION_DELAY = 12
 
 
 pytestmark = pytest.mark.usefixtures("add_initial_liquidity", "provide_token_to_peg_keepers", "mint_bob")
@@ -36,7 +36,7 @@ def test_update_no_delay(peg_keepers, swaps, redeemable_tokens, stablecoin, bob,
                     swap.add_liquidity([0, stablecoin.balanceOf(bob)], 0)
 
             t0 = pk.last_change()
-            boa.env.vm.patch.timestamp = t0 + ACTION_DELAY - 30
+            boa.env.vm.patch.timestamp = t0 + ACTION_DELAY - 3
             with boa.env.prank(peg_keeper_updater):
                 pk.update()
             assert pk.last_change() == t0

--- a/tests/stableborrow/stabilize/unitary/test_pk_profit.py
+++ b/tests/stableborrow/stabilize/unitary/test_pk_profit.py
@@ -153,7 +153,7 @@ def test_unprofitable_peg(swaps, peg_keepers, redeemable_tokens, stablecoin, ali
 
             set_fee(swap, 5 * 10**9)
 
-            boa.env.time_travel(15 * 60)
+            boa.env.time_travel(12)
             with boa.reverts('peg unprofitable'):  # dev: peg was unprofitable
                 with boa.env.prank(alice):
                     peg_keeper.update()


### PR DESCRIPTION
# About
Relating to June incident making `ACTION_DELAY=15 min` mutable and set `12 sec` by default. This will make spam attack infeasibly expensive (as if delay was 15 minutes) and allows to set `price_deviation` any big value as a patch.

# Tests
Tests are same and passed. Code change is straightforward to skip audit for this one.