### PR TITLE
Add zero address checks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on: [push]
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   EXPLORER_TOKEN: ${{ secrets.EXPLORER_TOKEN }}
+  WEB3_PROVIDER_URL: ${{ secrets.WEB3_PROVIDER_URL }}
   HYPOTHESIS_PROFILE: no-shrink
 
 jobs:

--- a/curve_stablecoin/controller.vy
+++ b/curve_stablecoin/controller.vy
@@ -58,14 +58,14 @@ CALLDATA_MAX_SIZE: constant(uint256) = c.CALLDATA_MAX_SIZE
 CALLBACK_DEPOSIT: constant(bytes4) = method_id(
     "callback_deposit(address,uint256,uint256,uint256,bytes)",
     output_type=bytes4,
-)
+)  # active_band=0, borrowed=0
 CALLBACK_REPAY: constant(bytes4) = method_id(
     "callback_repay(address,uint256,uint256,uint256,bytes)", output_type=bytes4
 )
 CALLBACK_LIQUIDATE: constant(bytes4) = method_id(
     "callback_liquidate(address,uint256,uint256,uint256,bytes)",
     output_type=bytes4,
-)
+)  # active_band=0
 
 MIN_AMM_FEE: constant(uint256) = 10**6  # 1e-12, still needs to be above 0
 MAX_RATE: constant(uint256) = 43959106799  # 300% APY
@@ -639,7 +639,7 @@ def create_loan(
     if _callbacker != empty(address):
         tkn.transfer(BORROWED_TOKEN, _callbacker, _debt)
         # If there is any unused debt, callbacker can send it to the user
-        more_collateral = self.execute_callback(
+        cb: IController.CallbackData = self.execute_callback(
             _callbacker,
             CALLBACK_DEPOSIT,
             _for,
@@ -647,7 +647,10 @@ def create_loan(
             _collateral,
             _debt,
             _calldata,
-        ).collateral
+        )
+        assert cb.active_band == 0, "Not available"
+        assert cb.borrowed == 0, "Not available"
+        more_collateral = cb.collateral
 
     total_collateral: uint256 = _collateral + more_collateral
 
@@ -864,7 +867,7 @@ def borrow_more(
     if _callbacker != empty(address):
         tkn.transfer(BORROWED_TOKEN, _callbacker, _debt)
         # If there is any unused debt, callbacker can send it to the user
-        more_collateral = self.execute_callback(
+        cb: IController.CallbackData = self.execute_callback(
             _callbacker,
             CALLBACK_DEPOSIT,
             _for,
@@ -872,7 +875,10 @@ def borrow_more(
             _collateral,
             _debt,
             _calldata,
-        ).collateral
+        )
+        assert cb.active_band == 0, "Not available"
+        assert cb.borrowed == 0, "Not available"
+        more_collateral = cb.collateral
 
     rate_mul: uint256 = self._add_collateral_borrow(
         _collateral + more_collateral, _debt, _for, False
@@ -911,6 +917,9 @@ def _repay_full(
     _cb: IController.CallbackData,
     _callbacker: address,
 ):
+    """
+    @notice Allows any value for cb.active_band to be indistinguishable with partial repay.
+    """
     if _callbacker == empty(address):
         _xy = extcall AMM.withdraw(_for, WAD)
 
@@ -1278,6 +1287,7 @@ def liquidate(
                 debt,
                 _calldata,
             )
+            assert cb.active_band == 0, "Not available"
             assert cb.borrowed >= to_repay, "no enough proceeds"
 
             tkn.transfer_from(BORROWED_TOKEN, _callbacker, self, to_repay)

--- a/curve_stablecoin/controller.vy
+++ b/curve_stablecoin/controller.vy
@@ -648,7 +648,7 @@ def create_loan(
             _debt,
             _calldata,
         )
-        assert cb.active_band == 0, "Not available"
+        # assert cb.active_band == 0, "Not available"
         assert cb.borrowed == 0, "Not available"
         more_collateral = cb.collateral
 
@@ -876,7 +876,7 @@ def borrow_more(
             _debt,
             _calldata,
         )
-        assert cb.active_band == 0, "Not available"
+        # assert cb.active_band == 0, "Not available"
         assert cb.borrowed == 0, "Not available"
         more_collateral = cb.collateral
 
@@ -1287,7 +1287,7 @@ def liquidate(
                 debt,
                 _calldata,
             )
-            assert cb.active_band == 0, "Not available"
+            # assert cb.active_band == 0, "Not available"
             assert cb.borrowed >= to_repay, "no enough proceeds"
 
             tkn.transfer_from(BORROWED_TOKEN, _callbacker, self, to_repay)

--- a/curve_stablecoin/controller.vy
+++ b/curve_stablecoin/controller.vy
@@ -648,8 +648,8 @@ def create_loan(
             _debt,
             _calldata,
         )
-        # assert cb.active_band == 0, "Not available"
-        assert cb.borrowed == 0, "Not available"
+        # assert cb.active_band == 0  # dev: Not available
+        assert cb.borrowed == 0  # dev: Not available
         more_collateral = cb.collateral
 
     total_collateral: uint256 = _collateral + more_collateral
@@ -876,8 +876,8 @@ def borrow_more(
             _debt,
             _calldata,
         )
-        # assert cb.active_band == 0, "Not available"
-        assert cb.borrowed == 0, "Not available"
+        # assert cb.active_band == 0  # dev: Not available
+        assert cb.borrowed == 0  # dev: Not available
         more_collateral = cb.collateral
 
     rate_mul: uint256 = self._add_collateral_borrow(

--- a/curve_stablecoin/lending/LendFactory.vy
+++ b/curve_stablecoin/lending/LendFactory.vy
@@ -94,10 +94,10 @@ def __init__(
 
     ownable.__init__()
     pausable.__init__()
-    assert _admin != empty(address)
+    # Checks zero _admin
     ownable._transfer_ownership(_admin)
 
-    assert _fee_receiver != empty(address)
+    # Checks zero _fee_receiver
     self._set_default_fee_receiver(_fee_receiver)
 
 

--- a/curve_stablecoin/lending/LendFactory.vy
+++ b/curve_stablecoin/lending/LendFactory.vy
@@ -82,6 +82,10 @@ def __init__(
         "VLT",  # Vault Blueprint
         "CTRV", # Controller View Blueprint
     ])
+    assert _amm_blueprint != empty(address)
+    assert _controller_blueprint != empty(address)
+    assert _vault_blueprint != empty(address)
+    assert _controller_view_blueprint != empty(address)
     # This is the only place where we set these blueprints
     blueprint_registry.set("AMM", _amm_blueprint)
     blueprint_registry.set("CTR", _controller_blueprint)
@@ -90,8 +94,10 @@ def __init__(
 
     ownable.__init__()
     pausable.__init__()
+    assert _admin != empty(address)
     ownable._transfer_ownership(_admin)
 
+    assert _fee_receiver != empty(address)
     self._set_default_fee_receiver(_fee_receiver)
 
 

--- a/curve_stablecoin/lending/LendFactory.vy
+++ b/curve_stablecoin/lending/LendFactory.vy
@@ -94,7 +94,7 @@ def __init__(
 
     ownable.__init__()
     pausable.__init__()
-    # Checks zero _admin
+    assert _admin != empty(address)
     ownable._transfer_ownership(_admin)
 
     # Checks zero _fee_receiver

--- a/curve_stablecoin/mpolicies/AggMonetaryPolicy4.vy
+++ b/curve_stablecoin/mpolicies/AggMonetaryPolicy4.vy
@@ -113,8 +113,8 @@ def __init__(admin: address,
              extra_const: uint256,
              _debt_ratio_ema_time: uint256):
     assert admin != empty(address)
-    assert price_oracle != empty(address)
-    assert controller_factory != empty(address)
+    assert price_oracle.address != empty(address)
+    assert controller_factory.address != empty(address)
     self.admin = admin
     PRICE_ORACLE = price_oracle
     CONTROLLER_FACTORY = controller_factory

--- a/curve_stablecoin/mpolicies/AggMonetaryPolicy4.vy
+++ b/curve_stablecoin/mpolicies/AggMonetaryPolicy4.vy
@@ -112,6 +112,9 @@ def __init__(admin: address,
              target_debt_fraction: uint256,
              extra_const: uint256,
              _debt_ratio_ema_time: uint256):
+    assert admin != empty(address)
+    assert price_oracle != empty(address)
+    assert controller_factory != empty(address)
     self.admin = admin
     PRICE_ORACLE = price_oracle
     CONTROLLER_FACTORY = controller_factory
@@ -137,6 +140,7 @@ def __init__(admin: address,
 @external
 def set_admin(admin: address):
     assert msg.sender == self.admin  # dev: only admin
+    assert admin != empty(address)
     self.admin = admin
     log SetAdmin(admin=admin)
 

--- a/tests/forked/settings.py
+++ b/tests/forked/settings.py
@@ -1,4 +1,4 @@
 import os
 
-WEB3_PROVIDER_URL = "https://eth.drpc.org"
+WEB3_PROVIDER_URL = os.getenv("WEB3_PROVIDER_URL")
 EXPLORER_TOKEN = os.getenv("EXPLORER_TOKEN")

--- a/tests/unitary/controller/test_borrow_more.py
+++ b/tests/unitary/controller/test_borrow_more.py
@@ -577,6 +577,31 @@ def test_borrow_more_from_wallet_and_callback(
         assert collateral_token_after["borrower"] == collateral_token_before["borrower"]
 
 
+def test_borrow_more_from_callback_reverts_when_callback_returns_borrowed(
+    controller,
+    collateral_token,
+    borrower_with_existing_loan,
+    dummy_callback,
+    get_calldata,
+    amounts,
+):
+    """Borrowing more rejects callback data with non-zero borrowed amount."""
+    borrower = borrower_with_existing_loan
+    callback_collateral = amounts["additional_collateral"]
+
+    boa.deal(collateral_token, dummy_callback, callback_collateral)
+
+    with boa.reverts(dev="Not available"):
+        controller.borrow_more(
+            0,
+            amounts["additional_debt"],
+            borrower,
+            dummy_callback,
+            get_calldata(1, callback_collateral),
+            sender=borrower,
+        )
+
+
 def test_borrow_more_no_loan_exists(
     controller,
     collateral_token,

--- a/tests/unitary/controller/test_create_loan.py
+++ b/tests/unitary/controller/test_create_loan.py
@@ -402,6 +402,34 @@ def test_create_loan_already_exists(
         )
 
 
+def test_create_loan_with_callback_reverts_when_callback_returns_borrowed(
+    controller,
+    collateral_token,
+    dummy_callback,
+    get_calldata,
+    amounts,
+):
+    """Loan creation rejects callback data with non-zero borrowed amount."""
+    borrower = boa.env.eoa
+    wallet_collateral = amounts["collateral"]
+    callback_collateral = amounts["collateral"] // 3
+
+    boa.deal(collateral_token, borrower, wallet_collateral)
+    boa.deal(collateral_token, dummy_callback, callback_collateral)
+    max_approve(collateral_token, controller, sender=borrower)
+
+    with boa.reverts(dev="Not available"):
+        controller.create_loan(
+            wallet_collateral,
+            amounts["debt"],
+            N_BANDS,
+            borrower,
+            dummy_callback,
+            get_calldata(1, callback_collateral),
+            sender=borrower,
+        )
+
+
 def test_create_loan_invalid_ticks(
     controller,
     collateral_token,

--- a/tests/unitary/lending/lend_factory/test_ctor_lf.py
+++ b/tests/unitary/lending/lend_factory/test_ctor_lf.py
@@ -1,3 +1,4 @@
+import pytest
 import boa
 from tests.utils.deployers import LENDING_FACTORY_DEPLOYER
 from tests.utils.constants import ZERO_ADDRESS
@@ -45,4 +46,38 @@ def test_ctor_reverts_if_fee_receiver_is_zero(admin, amm_impl, controller_impl, 
             controller_view_blueprint,
             admin,
             fee_receiver,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "zero_value"),
+    [
+        ("amm_blueprint", ZERO_ADDRESS),
+        ("controller_blueprint", ZERO_ADDRESS),
+        ("vault_blueprint", ZERO_ADDRESS),
+        ("controller_view_blueprint", ZERO_ADDRESS),
+        ("admin", ZERO_ADDRESS),
+    ],
+)
+def test_ctor_reverts_if_required_address_is_zero(
+    field, zero_value, admin, amm_impl, controller_impl, proto
+):
+    args = {
+        "amm_blueprint": amm_impl.address,
+        "controller_blueprint": controller_impl.address,
+        "vault_blueprint": proto.blueprints.vault.address,
+        "controller_view_blueprint": proto.blueprints.lend_controller_view.address,
+        "admin": admin,
+        "fee_receiver": boa.env.generate_address("fee_receiver"),
+    }
+    args[field] = zero_value
+
+    with boa.reverts():
+        LENDING_FACTORY_DEPLOYER.deploy(
+            args["amm_blueprint"],
+            args["controller_blueprint"],
+            args["vault_blueprint"],
+            args["controller_view_blueprint"],
+            args["admin"],
+            args["fee_receiver"],
         )

--- a/tests/unitary/mpolicies/agg_monetary_policy4/test_ctor_amp4.py
+++ b/tests/unitary/mpolicies/agg_monetary_policy4/test_ctor_amp4.py
@@ -237,3 +237,46 @@ def test_revert_extra_const_too_high(
                 MAX_EXTRA_CONST + 1,  # Too high
                 default_ema_time,
             )
+
+
+@pytest.mark.parametrize(
+    ("field", "zero_value"),
+    [
+        ("admin", ZERO_ADDRESS),
+        ("price_oracle", ZERO_ADDRESS),
+        ("mock_factory", ZERO_ADDRESS),
+    ],
+)
+def test_revert_zero_required_address(
+    field,
+    zero_value,
+    admin,
+    price_oracle,
+    mock_factory,
+    default_rate,
+    default_sigma,
+    default_target_debt_fraction,
+    default_extra_const,
+    default_ema_time,
+):
+    """Revert when a required constructor address is zero."""
+    args = {
+        "admin": admin,
+        "price_oracle": price_oracle.address,
+        "mock_factory": mock_factory.address,
+    }
+    args[field] = zero_value
+
+    with boa.env.prank(admin):
+        with boa.reverts():
+            AGG_MONETARY_POLICY4_DEPLOYER.deploy(
+                args["admin"],
+                args["price_oracle"],
+                args["mock_factory"],
+                [ZERO_ADDRESS] * 5,
+                default_rate,
+                default_sigma,
+                default_target_debt_fraction,
+                default_extra_const,
+                default_ema_time,
+            )

--- a/tests/unitary/mpolicies/agg_monetary_policy4/test_set_admin_amp4.py
+++ b/tests/unitary/mpolicies/agg_monetary_policy4/test_set_admin_amp4.py
@@ -3,6 +3,7 @@
 import boa
 
 from tests.utils import filter_logs
+from tests.utils.constants import ZERO_ADDRESS
 
 
 def test_default_behavior(mp, admin):
@@ -28,3 +29,10 @@ def test_revert_unauthorized(mp):
     with boa.env.prank(unauthorized):
         with boa.reverts(dev="only admin"):
             mp.set_admin(new_admin)
+
+
+def test_revert_zero_address(mp, admin):
+    """Admin cannot transfer admin rights to zero address."""
+    with boa.env.prank(admin):
+        with boa.reverts():
+            mp.set_admin(ZERO_ADDRESS)


### PR DESCRIPTION
CS-CURVE-LLV2-049
- Peg keepers are sorted in logical order(USDC, USDT, others) to easily add/remove, so it's too bulky to check for copies
- `self.execute_callback().borrowed` is ignored because method with special signature is called which should acknowledge used parameters.