### PR TITLE
chore: remove already tackled TODO

### DIFF
--- a/curve_stablecoin/lending/blueprint_registry.vy
+++ b/curve_stablecoin/lending/blueprint_registry.vy
@@ -7,7 +7,6 @@ event BlueprintSet:
 MAX_LENGTH: constant(uint8) = 10
 BLUEPRINT_REGISTRY_IDS: immutable(DynArray[String[4], MAX_LENGTH])
 _blueprints: HashMap[String[4], address]
-# TODO add to linting coverage
 
 
 @deploy


### PR DESCRIPTION
As per audit recommendation we removed the last TODO left in the source code that we're planning to deploy for LLv2. There's other TODOs left but they belong to code that either isn't produciton ready.