### PR TITLE
docs: add mpol recommendations

### DIFF
--- a/curve_stablecoin/controller.vy
+++ b/curve_stablecoin/controller.vy
@@ -364,6 +364,10 @@ def borrowed_token() -> IERC20:
 def _save_rate():
     """
     @notice Save current rate
+    @dev If the monetary policy is stateful `rate_write` MUST be permissioned
+    so that only the controller can call it. Otherwise one can circumvent the
+    reentrancy lock present in all the external methods that call `self._save_rate`
+    by calling `rate_write` directly.
     """
     rate: uint256 = min(extcall self._monetary_policy.rate_write(), MAX_RATE)
     extcall AMM.set_rate(rate)


### PR DESCRIPTION
Document behavior of monetary policies when interacting from the controller, as recommended by auditors.